### PR TITLE
update token url

### DIFF
--- a/lib/omniauth-withings2/version.rb
+++ b/lib/omniauth-withings2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Withings
-    VERSION = "0.2.0"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/omniauth/strategies/withings2.rb
+++ b/lib/omniauth/strategies/withings2.rb
@@ -13,6 +13,7 @@ module OmniAuth
 
       option :response_type, 'code'
       option :authorize_options, %i(scope response_type redirect_uri)
+      option :access_token_params, { action: 'requesttoken' }
 
       def build_access_token
         options.token_params.merge!(
@@ -25,11 +26,11 @@ module OmniAuth
         "Basic " + Base64.strict_encode64("#{options[:client_id]}:#{options[:client_secret]}")
       end
 
-      def query_string
-        # Using state and code params in the callback_url causes a mismatch with
-        # the value set in the withings2 application configuration, so we're skipping them
-        ''
-      end
+      # def query_string
+      #   # Using state and code params in the callback_url causes a mismatch with
+      #   # the value set in the withings2 application configuration, so we're skipping them
+      #   ''
+      # end
 
       uid do
         access_token.params['userid']

--- a/lib/omniauth/strategies/withings2.rb
+++ b/lib/omniauth/strategies/withings2.rb
@@ -8,7 +8,7 @@ module OmniAuth
       option :client_options, {
           :site          => 'https://account.withings.com',
           :authorize_url => 'https://account.withings.com/oauth2_user/authorize2',
-          :token_url     => 'https://account.withings.com/oauth2/token'
+          :token_url     => 'https://wbsapi.withings.net/v2/oauth2',
       }
 
       option :response_type, 'code'

--- a/lib/omniauth/strategies/withings2.rb
+++ b/lib/omniauth/strategies/withings2.rb
@@ -6,16 +6,23 @@ module OmniAuth
 
       option :name, 'withings2'
       option :client_options, {
-          :site          => 'https://account.withings.com',
-          :authorize_url => 'https://account.withings.com/oauth2_user/authorize2',
-          :token_url     => 'https://wbsapi.withings.net/v2/oauth2',
+        :site          => 'https://account.withings.com',
+        :authorize_url => 'https://account.withings.com/oauth2_user/authorize2',
+        :token_url     => 'https://wbsapi.withings.net/v2/oauth2',
       }
 
       option :response_type, 'code'
       option :authorize_options, %i(scope response_type redirect_uri)
 
       def build_access_token
-        options.token_params.merge!(:headers => {'Authorization' => basic_auth_header })
+        options.token_params.merge!(
+          action: 'requesttoken',
+          grant_type: 'authorization_code',
+          client_id: options[:client_id],
+          client_secret: options[:client_secret],
+          # redirect_uri: 'https://www.withings.com'
+          headers: { 'Authorization' => basic_auth_header }
+        )
         super
       end
 

--- a/lib/omniauth/strategies/withings2.rb
+++ b/lib/omniauth/strategies/withings2.rb
@@ -9,14 +9,17 @@ module OmniAuth
         :site          => 'https://account.withings.com',
         :authorize_url => 'https://account.withings.com/oauth2_user/authorize2',
         :token_url     => 'https://wbsapi.withings.net/v2/oauth2',
+        extract_access_token: proc { |client, hash|
+          ::OAuth2::Client::DEFAULT_EXTRACT_ACCESS_TOKEN.call(client, hash['body'])
+        }
       }
 
       option :response_type, 'code'
       option :authorize_options, %i(scope response_type redirect_uri)
-      option :access_token_params, { action: 'requesttoken' }
 
       def build_access_token
         options.token_params.merge!(
+          action: 'requesttoken',
           headers: { 'Authorization' => basic_auth_header }
         )
         super
@@ -26,11 +29,11 @@ module OmniAuth
         "Basic " + Base64.strict_encode64("#{options[:client_id]}:#{options[:client_secret]}")
       end
 
-      # def query_string
-      #   # Using state and code params in the callback_url causes a mismatch with
-      #   # the value set in the withings2 application configuration, so we're skipping them
-      #   ''
-      # end
+      def query_string
+        # Using state and code params in the callback_url causes a mismatch with
+        # the value set in the withings2 application configuration, so we're skipping them
+        ''
+      end
 
       uid do
         access_token.params['userid']

--- a/lib/omniauth/strategies/withings2.rb
+++ b/lib/omniauth/strategies/withings2.rb
@@ -16,11 +16,6 @@ module OmniAuth
 
       def build_access_token
         options.token_params.merge!(
-          action: 'requesttoken',
-          grant_type: 'authorization_code',
-          client_id: options[:client_id],
-          client_secret: options[:client_secret],
-          # redirect_uri: 'https://www.withings.com'
           headers: { 'Authorization' => basic_auth_header }
         )
         super
@@ -30,11 +25,11 @@ module OmniAuth
         "Basic " + Base64.strict_encode64("#{options[:client_id]}:#{options[:client_secret]}")
       end
 
-      def query_string
-        # Using state and code params in the callback_url causes a mismatch with
-        # the value set in the withings2 application configuration, so we're skipping them
-        ''
-      end
+      # def query_string
+      #   # Using state and code params in the callback_url causes a mismatch with
+      #   # the value set in the withings2 application configuration, so we're skipping them
+      #   ''
+      # end
 
       uid do
         access_token.params['userid']

--- a/lib/omniauth/strategies/withings2.rb
+++ b/lib/omniauth/strategies/withings2.rb
@@ -25,11 +25,11 @@ module OmniAuth
         "Basic " + Base64.strict_encode64("#{options[:client_id]}:#{options[:client_secret]}")
       end
 
-      # def query_string
-      #   # Using state and code params in the callback_url causes a mismatch with
-      #   # the value set in the withings2 application configuration, so we're skipping them
-      #   ''
-      # end
+      def query_string
+        # Using state and code params in the callback_url causes a mismatch with
+        # the value set in the withings2 application configuration, so we're skipping them
+        ''
+      end
 
       uid do
         access_token.params['userid']

--- a/spec/omniauth/strategies/withings2_spec.rb
+++ b/spec/omniauth/strategies/withings2_spec.rb
@@ -35,7 +35,7 @@ describe "OmniAuth::Strategies::Withings2" do
     end
 
     it 'has correct token url' do
-      expect(subject.options.client_options.token_url).to eq('https://account.withings.com/oauth2/token')
+      expect(subject.options.client_options.token_url).to eq('https://wbsapi.withings.net/v2/oauth2')
     end
   end
 
@@ -53,7 +53,7 @@ describe "OmniAuth::Strategies::Withings2" do
   context 'uid' do
     before :each do
       access_token = double('access_token')
-      allow(access_token).to receive('params') { { 'user_id' => '123ABC' } }
+      allow(access_token).to receive('params') { { 'userid' => '123ABC' } }
       allow(subject).to receive(:access_token) { access_token }
     end
 


### PR DESCRIPTION
brings oauth2 implementation in accordance with new API endpoint
mentioned here: https://support.withings.com/hc/en-us/articles/360016745358-Deprecating-access-and-refresh-tokens-endpoints

related https://github.com/healthline/platejoy/pull/3010
close https://github.com/healthline/platejoy/issues/2732